### PR TITLE
Fix ambiguity of `clamp` use, prefer int version

### DIFF
--- a/src/burst.cpp
+++ b/src/burst.cpp
@@ -103,7 +103,7 @@ void Burst::process(const ProcessArgs &args) {
 	float randomDelta = 0;
 
 	timeParam = clamp(params[TIME_PARAM].getValue() + (params[TIME_ATT_PARAM].getValue() * inputs[TIME_INPUT].getVoltage() / 10.0 * MAX_TIME), 0.0f, MAX_TIME);
-	pulseParam = clamp((int)params[REP_PARAM].getValue() + (inputs[REP_INPUT].getVoltage() * params[REP_ATT_PARAM].getValue() / 10.0 * MAX_REPS), 0, MAX_REPS);
+	pulseParam = clamp((int)params[REP_PARAM].getValue() + (int)(inputs[REP_INPUT].getVoltage() * params[REP_ATT_PARAM].getValue() / 10.0 * MAX_REPS), 0, MAX_REPS);
 
 	//exponential scaling for timeparam
 	timeParam = (exp(timeParam) - 1) / (euler - 1);


### PR DESCRIPTION
The `clamp` function from Rack has an `int` and `float` version.
Which one was being called here was unclear, since `getVoltage()` returns a float and converts the 1st argument in the function to it, ending up with a `clamp(float, int, int)`. This can generate a compiler warning in some conditions.

Fix should be pretty clear, we just force it to use `int` instead of leaving it ambiguous.
Looking at the rest of the code seems to me the intention was to use `int` anyway.
